### PR TITLE
DOC: Revise query module doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/
 data/
 dist/
 trash/
+.venv
+.vscode

--- a/src/tradingview_screener/query.py
+++ b/src/tradingview_screener/query.py
@@ -227,7 +227,7 @@ class Query:
     By default, the `Query` will select the columns: `name`, `close`, `volume`, `market_cap_basic`,
     but you override that
     >>> (Query()
-    ...  .select('open', 'high', 'low', 'VWAP', 'MACD.macd', 'RSI', 'Price to Earnings Ratio (TTM)')
+    ...  .select('open', 'high', 'low', 'VWAP', 'MACD.macd', 'RSI', 'price_earnings_ttm')
     ...  .get_scanner_data())
     (18060,
               ticker    open     high  ...  MACD.macd        RSI  price_earnings_ttm
@@ -249,7 +249,7 @@ class Query:
     Now let's do some queries using the `WHERE` statement, select all the stocks that the `close` is
     bigger or equal than 350
     >>> (Query()
-    ...  .select('close', 'volume', '52 Week High')
+    ...  .select('close', 'volume', 'price_52_week_high')
     ...  .where(Column('close') >= 350)
     ...  .get_scanner_data())
     (159,
@@ -557,7 +557,7 @@ class Query:
          49                    CRYPTOCAP:OP  ...     cfd
          [50 rows x 3 columns])
 
-        :param markets: one or more markets from `tradingview_screener.constants.MARKETS`
+        :param markets: one or more markets
         :return: Self
         """
         if len(markets) == 1:
@@ -584,18 +584,17 @@ class Query:
                  ticker  name   market  close   volume    VWAP  MACD.macd
          0  NASDAQ:TSLA  TSLA  america    186  3519931  185.53   2.371601)
 
-        To set tickers from multiple markets we need to update the markets that include them:
+        To set multiple tickers:
         >>> (Query()
-        ...  .set_markets('america', 'italy', 'vietnam')
-        ...  .set_tickers('NYSE:GME', 'AMEX:SPY', 'MIL:RACE', 'HOSE:VIX')
+        ...  .select('name', 'close', 'volume', 'market_cap_basic')
+        ...  .set_tickers('NYSE:GME', 'MIL:RACE', 'HOSE:VIX')
         ...  .get_scanner_data())
-        (4,
-              ticker  name     close    volume  market_cap_basic
-         0  HOSE:VIX   VIX  16700.00  33192500      4.568961e+08
-         1  AMEX:SPY   SPY    544.35   1883562               NaN
-         2  NYSE:GME   GME     23.80   3116758      1.014398e+10
-         3  MIL:RACE  RACE    393.30    122878      1.006221e+11)
-
+        (3,
+            ticker  name    close    volume  market_cap_basic
+        0  MIL:RACE  RACE    300.4    351982      8.161551e+10
+        1  NYSE:GME   GME     21.8   6429236      9.781469e+09
+        2  HOSE:VIX   VIX  17750.0  26524292      1.666686e+09)
+ 
         :param tickers: One or more tickers, syntax: `exchange:symbol`
         :return: Self
         """
@@ -641,9 +640,7 @@ class Query:
          8           NSE:LT          LT   3532.500000    5879660      5.816100e+10
          9         LSE:SHEL        SHEL   2732.500000    7448315      2.210064e+11)
 
-        You can find the full list of indices in [`constants.INDICES`](constants.html#INDICES),
-        just note that the syntax is
-        `SYML:{source};{symbol}`.
+        Note that the syntax to specify an index is `SYML:{source};{symbol}`.
 
         :param indexes: One or more strings representing the financial indexes to filter by
         :return: An instance of the `Query` class with the filter applied


### PR DESCRIPTION
Hi @shner-elmo

Thanks for this great package!

Whilst having a dig around in the code I noticed that some of the doc for the `Query` class no longer reflects the implementation. This PR makes the following revisions:
- renames column names in the examples from "display name" to "name" (display names no longer return)
- `set_index` and `set_market`: removes reference to old `tradingview_screener.constants` module.
- `set_tickers`: revises doc lines that refer to the need to set markets - no longer relevant given that the method resets markets (as advised towards the start of the docstring). Also `AMEX:SPY` no longer a valid ticker.

Also adds '.venv' and '.vscode' to gitignore.