### PR TITLE
Fix Query.copy endpoint and nested state isolation

### DIFF
--- a/src/tradingview_screener/query.py
+++ b/src/tradingview_screener/query.py
@@ -754,9 +754,8 @@ class Query:
         return rows_count, df
 
     def copy(self) -> Query:
-        new = Query()
-        new.query = self.query.copy()
-        return new
+        """Return an independent query, preserving its market endpoint and state."""
+        return copy.deepcopy(self)
 
     def __repr__(self) -> str:
         return f'< {pprint.pformat(self.query)}\n url={self.url!r} >'

--- a/tests/test_query_copy.py
+++ b/tests/test_query_copy.py
@@ -1,0 +1,21 @@
+"""Query-copy regressions: no scanner requests are made."""
+import pytest
+
+from tradingview_screener.query import Query
+from tradingview_screener.screeners import forex, options
+
+
+@pytest.mark.parametrize('original', [forex(), options('NASDAQ:AAPL'), Query()])
+def test_copy_preserves_endpoint_and_independent_nested_state(original):
+    clone = original.copy()
+    assert clone == original
+    assert clone is not original
+    assert clone.url == original.url
+    original_range = original.query['range'][:]
+    clone.offset(17).limit(31)
+    assert original.query['range'] == original_range
+    assert clone.query['range'] == [17, 31]
+    original.query.setdefault('symbols', {})['tickers'] = ['NASDAQ:AAPL']
+    independent = original.copy()
+    independent.query['symbols']['tickers'].append('NASDAQ:MSFT')
+    assert original.query['symbols']['tickers'] == ['NASDAQ:AAPL']


### PR DESCRIPTION
Copying a forex or options query currently resets its endpoint to the default US stock scanner, and changing the copied range or symbols can mutate the original query. Deep-copy the complete Query object so the copy preserves its endpoint and has independent nested state.

Validation: 31 offline tests passed (10 live scanner tests excluded), including new stock, forex, and options copy regressions. No live scanner requests were made.
